### PR TITLE
Removes rustc serializer and add to/from conversion of String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nullvec"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["sinhrks <sinhrks@gmail.com>"]
 license = "BSD-3-Clause"
 readme = "README.md"
 description = "Rust nullable vector, which can contain null(missing) values as element"
 keywords = [ "Nan", "Null", "Missing", "Masked", "Vec"]
+categories = [ "data-structures" ]
 documentation = "https://docs.rs/nullvec/"
 repository = "https://github.com/sinhrks/rust-nullvec"
 
 [dependencies]
-num = "0.1.36"
-rustc-serialize = "0.3.21"
+num = "0.1.40"

--- a/src/generic/convert.rs
+++ b/src/generic/convert.rs
@@ -275,6 +275,7 @@ macro_rules! add_scalar_conversion {
             }
         }
 
+
         impl From<Scalar> for Nullable<$t> {
             fn from(value: Scalar) -> Self {
                 match value {
@@ -286,6 +287,43 @@ macro_rules! add_scalar_conversion {
         }
     }
 }
+
+
+
+// This is the same than above but without the From<Scalar>
+// Used only for String to avoid collisions with other conversions
+macro_rules! add_scalar_conversion_str {
+    ($t:ident) => {
+
+        impl From<$t> for Scalar {
+            fn from(value: $t) -> Self {
+                Scalar::$t(value)
+            }
+        }
+
+        impl From<Nullable<$t>> for Scalar {
+            fn from(value: Nullable<$t>) -> Self {
+                match value {
+                    Nullable::Null => Scalar::Null,
+                    Nullable::Value(val) => Scalar::$t(val),
+                }
+            }
+        }
+
+        impl From<Scalar> for Nullable<$t> {
+            fn from(value: Scalar) -> Self {
+                match value {
+                    Scalar::Null => Nullable::Null,
+                    Scalar::$t(val) => Nullable::Value(val),
+                    _ => panic!("Unable to convert to primitive")
+                }
+            }
+        }
+    }
+}
+
+
+
 add_scalar_conversion!(i64);
 add_scalar_conversion!(i32);
 add_scalar_conversion!(i16);
@@ -299,359 +337,33 @@ add_scalar_conversion!(usize);
 add_scalar_conversion!(f64);
 add_scalar_conversion!(f32);
 add_scalar_conversion!(bool);
-add_scalar_conversion!(String);
+// String does not add a From<Scalar> impl to not conflict with the impls below
+add_scalar_conversion_str!(String);
 
-// &str handling
-//
+// &str and String conversions
+// Libraries serializing Scalars will first create strings from them before writing them out
+
 impl<'a> From<&'a str> for Scalar {
     fn from(value: &'a str) -> Self {
-        Scalar::String(value.to_string())
+        if value == "Null" {
+            Scalar::Null
+        } else {
+            value.parse().map(Scalar::i64)
+                .or_else(|_| value.parse().map(Scalar::f64)
+                         .or_else(|_| value.parse().map(Scalar::bool)))
+                .unwrap_or_else(|_| Scalar::String(value.to_string()))
+        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-
-    use super::super::{Array, Scalar};
-    use nullvec::NullVec;
-
-    #[test]
-    #[should_panic]
-    fn test_empty_scalar_to_array() {
-        let vals: Vec<Scalar> = vec![];
-        let _: Array = vals.into();
-    }
-
-    #[test]
-    fn test_i64_vec_to_array() {
-        let exp: Array = Array::Int64Array(NullVec::new(vec![1, 2]));
-
-        // Into
-        let vals: Vec<i64> = vec![1, 2];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::i64(1), Scalar::i64(2)];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        // From
-        let vals: Vec<i64> = vec![1, 2];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::i64(1), Scalar::i64(2)];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_i64_array_to_vec() {
-        let exp: Vec<i64> = vec![1, 2];
-        let exps: Vec<Scalar> = vec![Scalar::i64(1), Scalar::i64(2)];
-
-        // Into
-        let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
-        let res: Vec<i64> = vals.into();
-        assert_eq!(res, exp);
-
-        let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
-        let res: Vec<Scalar> = vals.into();
-        assert_eq!(res, exps);
-
-        // From
-        let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
-        let res: Vec<i64> = Vec::from(vals);
-        assert_eq!(res, exp);
-
-        let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
-        let res: Vec<Scalar> = Vec::from(vals);
-        assert_eq!(res, exps);
-    }
-
-    #[test]
-    fn test_usize_vec_to_array() {
-        let exp: Array = Array::UsizeArray(NullVec::new(vec![1, 2]));
-
-        // Into
-        let vals: Vec<usize> = vec![1, 2];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::usize(1), Scalar::usize(2)];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        // From
-        let vals: Vec<usize> = vec![1, 2];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::usize(1), Scalar::usize(2)];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_usize_array_to_vec() {
-        let exp: Vec<usize> = vec![1, 2];
-        let exps: Vec<Scalar> = vec![Scalar::usize(1), Scalar::usize(2)];
-
-        // Into
-        let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
-        let res: Vec<usize> = vals.into();
-        assert_eq!(res, exp);
-
-        let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
-        let res: Vec<Scalar> = vals.into();
-        assert_eq!(res, exps);
-
-        // From
-        let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
-        let res: Vec<usize> = Vec::from(vals);
-        assert_eq!(res, exp);
-
-        let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
-        let res: Vec<Scalar> = Vec::from(vals);
-        assert_eq!(res, exps);
-    }
-
-    #[test]
-    fn test_f64_vec_to_array() {
-        let exp: Array = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
-
-        // Into
-        let vals: Vec<f64> = vec![1.1, 2.2];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::f64(1.1), Scalar::f64(2.2)];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        // From
-        let vals: Vec<f64> = vec![1.1, 2.2];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::f64(1.1), Scalar::f64(2.2)];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_f64_array_to_vec() {
-        let exp: Vec<f64> = vec![1.1, 2.2];
-        let exps: Vec<Scalar> = vec![Scalar::f64(1.1), Scalar::f64(2.2)];
-
-        // Into
-        let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
-        let res: Vec<f64> = vals.into();
-        assert_eq!(res, exp);
-
-        let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
-        let res: Vec<Scalar> = vals.into();
-        assert_eq!(res, exps);
-
-        // From
-        let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
-        let res: Vec<f64> = Vec::from(vals);
-        assert_eq!(res, exp);
-
-        let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
-        let res: Vec<Scalar> = Vec::from(vals);
-        assert_eq!(res, exps);
-    }
-
-    #[test]
-    fn test_bool_vec_to_array() {
-        let exp: Array = Array::BoolArray(NullVec::new(vec![true, false]));
-
-        // Into
-        let vals: Vec<bool> = vec![true, false];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::bool(true), Scalar::bool(false)];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        // From
-        let vals: Vec<bool> = vec![true, false];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::bool(true), Scalar::bool(false)];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_bool_array_to_vec() {
-        let exp: Vec<bool> = vec![true, false];
-        let exps: Vec<Scalar> = vec![Scalar::bool(true), Scalar::bool(false)];
-
-        // Into
-        let vals = Array::BoolArray(NullVec::new(vec![true, false]));
-        let res: Vec<bool> = vals.into();
-        assert_eq!(res, exp);
-
-        let vals = Array::BoolArray(NullVec::new(vec![true, false]));
-        let res: Vec<Scalar> = vals.into();
-        assert_eq!(res, exps);
-
-        // From
-        let vals = Array::BoolArray(NullVec::new(vec![true, false]));
-        let res: Vec<bool> = Vec::from(vals);
-        assert_eq!(res, exp);
-
-        let vals = Array::BoolArray(NullVec::new(vec![true, false]));
-        let res: Vec<Scalar> = Vec::from(vals);
-        assert_eq!(res, exps);
-    }
-
-    #[test]
-    fn test_str_vec_to_array() {
-        let exp: Array = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
-
-        // Into
-        let vals: Vec<String> = vec!["a".to_string(), "b".to_string()];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        let vals: Vec<&str> = vec!["a", "b"];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::String("a".to_string()),
-                                     Scalar::String("b".to_string())];
-        let res: Array = vals.into();
-        assert_eq!(res, exp);
-
-        // From
-        let vals: Vec<String> = vec!["a".to_string(), "b".to_string()];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-
-        let vals: Vec<&str> = vec!["a", "b"];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-
-        let vals: Vec<Scalar> = vec![Scalar::String("a".to_string()),
-                                     Scalar::String("b".to_string())];
-        let res = Array::from(vals);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_str_array_to_vec() {
-        let exp: Vec<String> = vec!["a".to_string(), "b".to_string()];
-        let exps: Vec<Scalar> = vec![Scalar::String("a".to_string()),
-                                     Scalar::String("b".to_string())];
-
-        // Into
-        let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
-        let res: Vec<String> = vals.into();
-        assert_eq!(res, exp);
-
-        let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
-        let res: Vec<Scalar> = vals.into();
-        assert_eq!(res, exps);
-
-        // From
-        let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
-        let res: Vec<String> = Vec::from(vals);
-        assert_eq!(res, exp);
-
-        let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
-        let res: Vec<Scalar> = Vec::from(vals);
-        assert_eq!(res, exps);
-    }
-
-    #[test]
-    fn test_i64_primitives_to_scalar() {
-        let exp = Scalar::i64(1);
-
-        let res: Scalar = 1i64.into();
-        assert_eq!(res, exp);
-
-        let res: Scalar = Scalar::from(1i64);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_i64_scalar_to_primitives() {
-        let res: i64 = Scalar::i64(1).into();
-        assert_eq!(res, 1);
-
-        let res: i64 = i64::from(Scalar::i64(1));
-        assert_eq!(res, 1);
-    }
-
-    #[test]
-    fn test_f64_primitives_to_scalar() {
-        let exp = Scalar::f64(1.1);
-
-        let res: Scalar = (1.1).into();
-        assert_eq!(res, exp);
-
-        let res: Scalar = Scalar::from(1.1);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_f64_scalar_to_primitives() {
-        let res: f64 = Scalar::f64(1.1).into();
-        assert_eq!(res, 1.1);
-
-        let res: f64 = f64::from(Scalar::f64(1.1));
-        assert_eq!(res, 1.1);
-    }
-
-    #[test]
-    fn test_bool_primitives_to_scalar() {
-        let exp = Scalar::bool(true);
-
-        let res: Scalar = true.into();
-        assert_eq!(res, exp);
-
-        let res: Scalar = Scalar::from(true);
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_bool_scalar_to_primitives() {
-        let res: bool = Scalar::bool(true).into();
-        assert_eq!(res, true);
-
-        let res: bool = bool::from(Scalar::bool(true));
-        assert_eq!(res, true);
-    }
-
-    #[test]
-    fn test_str_primitives_to_scalar() {
-        let exp = Scalar::String("a".to_string());
-
-        let res: Scalar = "a".to_string().into();
-        assert_eq!(res, exp);
-
-        let res: Scalar = Scalar::from("a".to_string());
-        assert_eq!(res, exp);
-
-        // &str
-        let res: Scalar = "a".into();
-        assert_eq!(res, exp);
-
-        let res: Scalar = Scalar::from("a");
-        assert_eq!(res, exp);
-    }
-
-    #[test]
-    fn test_str_scalar_to_primitives() {
-        let res: String = Scalar::String("a".to_string()).into();
-        assert_eq!(res, "a".to_string());
-
-        let res: String = String::from(Scalar::String("a".to_string()));
-        assert_eq!(res, "a".to_string());
+impl From<Scalar> for String {
+    fn from(value: Scalar) -> Self {
+        match value {
+            Scalar::Null => "Null".to_string(),
+            Scalar::String(val) => val,
+            _ => value.to_string()
+        }
     }
 }
+
+

--- a/src/generic/mod.rs
+++ b/src/generic/mod.rs
@@ -8,7 +8,7 @@ mod scalar_impl;
 
 /// Generic scalar which can contain arbitrary primitive types.
 #[allow(non_camel_case_types)]
-#[derive(RustcDecodable, RustcEncodable, Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Scalar {
     /// Store `i64` value
     i64(i64),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate num;
-extern crate rustc_serialize;
 
 // macro must be defined first to be usable in other modules
 #[macro_use]

--- a/src/nullvec/nullvec_impl.rs
+++ b/src/nullvec/nullvec_impl.rs
@@ -71,7 +71,7 @@ impl<T: Clone + NullStorable> NullVec<T> {
 
 
 impl<T: Clone + NullStorable> NullVec<T> {
-    /// Returns `NullVec<T>`` which has the same length as the caller
+    /// Returns `NullVec<T>` which has the same length as the caller
     /// whose values are all `Null`.
     ///
     /// # Examples

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -1,0 +1,454 @@
+extern crate nullvec;
+use nullvec::prelude::*;
+
+#[test]
+#[should_panic]
+fn test_empty_scalar_to_array() {
+    let vals: Vec<Scalar> = vec![];
+    let _: Array = vals.into();
+}
+
+#[test]
+fn test_i64_vec_to_array() {
+    let exp: Array = Array::Int64Array(NullVec::new(vec![1, 2]));
+
+    // Into
+    let vals: Vec<i64> = vec![1, 2];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::i64(1), Scalar::i64(2)];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    // From
+    let vals: Vec<i64> = vec![1, 2];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::i64(1), Scalar::i64(2)];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_i64_array_to_vec() {
+    let exp: Vec<i64> = vec![1, 2];
+    let exps: Vec<Scalar> = vec![Scalar::i64(1), Scalar::i64(2)];
+
+    // Into
+    let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
+    let res: Vec<i64> = vals.into();
+    assert_eq!(res, exp);
+
+    let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
+    let res: Vec<Scalar> = vals.into();
+    assert_eq!(res, exps);
+
+    // From
+    let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
+    let res: Vec<i64> = Vec::from(vals);
+    assert_eq!(res, exp);
+
+    let vals = Array::Int64Array(NullVec::new(vec![1, 2]));
+    let res: Vec<Scalar> = Vec::from(vals);
+    assert_eq!(res, exps);
+}
+
+#[test]
+fn test_usize_vec_to_array() {
+    let exp: Array = Array::UsizeArray(NullVec::new(vec![1, 2]));
+
+    // Into
+    let vals: Vec<usize> = vec![1, 2];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::usize(1), Scalar::usize(2)];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    // From
+    let vals: Vec<usize> = vec![1, 2];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::usize(1), Scalar::usize(2)];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_usize_array_to_vec() {
+    let exp: Vec<usize> = vec![1, 2];
+    let exps: Vec<Scalar> = vec![Scalar::usize(1), Scalar::usize(2)];
+
+    // Into
+    let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
+    let res: Vec<usize> = vals.into();
+    assert_eq!(res, exp);
+
+    let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
+    let res: Vec<Scalar> = vals.into();
+    assert_eq!(res, exps);
+
+    // From
+    let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
+    let res: Vec<usize> = Vec::from(vals);
+    assert_eq!(res, exp);
+
+    let vals = Array::UsizeArray(NullVec::new(vec![1, 2]));
+    let res: Vec<Scalar> = Vec::from(vals);
+    assert_eq!(res, exps);
+}
+
+#[test]
+fn test_f64_vec_to_array() {
+    let exp: Array = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
+
+    // Into
+    let vals: Vec<f64> = vec![1.1, 2.2];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::f64(1.1), Scalar::f64(2.2)];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    // From
+    let vals: Vec<f64> = vec![1.1, 2.2];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::f64(1.1), Scalar::f64(2.2)];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_f64_array_to_vec() {
+    let exp: Vec<f64> = vec![1.1, 2.2];
+    let exps: Vec<Scalar> = vec![Scalar::f64(1.1), Scalar::f64(2.2)];
+
+    // Into
+    let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
+    let res: Vec<f64> = vals.into();
+    assert_eq!(res, exp);
+
+    let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
+    let res: Vec<Scalar> = vals.into();
+    assert_eq!(res, exps);
+
+    // From
+    let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
+    let res: Vec<f64> = Vec::from(vals);
+    assert_eq!(res, exp);
+
+    let vals = Array::Float64Array(NullVec::new(vec![1.1, 2.2]));
+    let res: Vec<Scalar> = Vec::from(vals);
+    assert_eq!(res, exps);
+}
+
+#[test]
+fn test_bool_vec_to_array() {
+    let exp: Array = Array::BoolArray(NullVec::new(vec![true, false]));
+
+    // Into
+    let vals: Vec<bool> = vec![true, false];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::bool(true), Scalar::bool(false)];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    // From
+    let vals: Vec<bool> = vec![true, false];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::bool(true), Scalar::bool(false)];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_bool_array_to_vec() {
+    let exp: Vec<bool> = vec![true, false];
+    let exps: Vec<Scalar> = vec![Scalar::bool(true), Scalar::bool(false)];
+
+    // Into
+    let vals = Array::BoolArray(NullVec::new(vec![true, false]));
+    let res: Vec<bool> = vals.into();
+    assert_eq!(res, exp);
+
+    let vals = Array::BoolArray(NullVec::new(vec![true, false]));
+    let res: Vec<Scalar> = vals.into();
+    assert_eq!(res, exps);
+
+    // From
+    let vals = Array::BoolArray(NullVec::new(vec![true, false]));
+    let res: Vec<bool> = Vec::from(vals);
+    assert_eq!(res, exp);
+
+    let vals = Array::BoolArray(NullVec::new(vec![true, false]));
+    let res: Vec<Scalar> = Vec::from(vals);
+    assert_eq!(res, exps);
+}
+
+#[test]
+fn test_str_vec_to_array() {
+    let exp: Array = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
+
+    // Into
+    let vals: Vec<String> = vec!["a".to_string(), "b".to_string()];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    let vals: Vec<&str> = vec!["a", "b"];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::String("a".to_string()),
+                                 Scalar::String("b".to_string())];
+    let res: Array = vals.into();
+    assert_eq!(res, exp);
+
+    // From
+    let vals: Vec<String> = vec!["a".to_string(), "b".to_string()];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+
+    let vals: Vec<&str> = vec!["a", "b"];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+
+    let vals: Vec<Scalar> = vec![Scalar::String("a".to_string()),
+                                 Scalar::String("b".to_string())];
+    let res = Array::from(vals);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_str_array_to_vec() {
+    let exp: Vec<String> = vec!["a".to_string(), "b".to_string()];
+    let exps: Vec<Scalar> = vec![Scalar::String("a".to_string()),
+                                 Scalar::String("b".to_string())];
+
+    // Into
+    let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
+    let res: Vec<String> = vals.into();
+    assert_eq!(res, exp);
+
+    let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
+    let res: Vec<Scalar> = vals.into();
+    assert_eq!(res, exps);
+
+    // From
+    let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
+    let res: Vec<String> = Vec::from(vals);
+    assert_eq!(res, exp);
+
+    let vals = Array::StringArray(NullVec::new(vec!["a".to_string(), "b".to_string()]));
+    let res: Vec<Scalar> = Vec::from(vals);
+    assert_eq!(res, exps);
+}
+
+#[test]
+fn test_i64_primitives_to_scalar() {
+    let exp = Scalar::i64(1);
+
+    let res: Scalar = 1i64.into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from(1i64);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_i64_scalar_to_primitives() {
+    let res: i64 = Scalar::i64(1).into();
+    assert_eq!(res, 1);
+
+    let res: i64 = i64::from(Scalar::i64(1));
+    assert_eq!(res, 1);
+}
+
+#[test]
+fn test_f64_primitives_to_scalar() {
+    let exp = Scalar::f64(1.1);
+
+    let res: Scalar = (1.1).into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from(1.1);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_f64_scalar_to_primitives() {
+    let res: f64 = Scalar::f64(1.1).into();
+    assert_eq!(res, 1.1);
+
+    let res: f64 = f64::from(Scalar::f64(1.1));
+    assert_eq!(res, 1.1);
+}
+
+#[test]
+fn test_bool_primitives_to_scalar() {
+    let exp = Scalar::bool(true);
+
+    let res: Scalar = true.into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from(true);
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_bool_scalar_to_primitives() {
+    let res: bool = Scalar::bool(true).into();
+    assert_eq!(res, true);
+
+    let res: bool = bool::from(Scalar::bool(true));
+    assert_eq!(res, true);
+}
+
+#[test]
+fn test_str_primitives_to_scalar() {
+    let exp = Scalar::String("a".to_string());
+
+    let res: Scalar = "a".to_string().into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from("a".to_string());
+    assert_eq!(res, exp);
+
+    // &str
+    let res: Scalar = "a".into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from("a");
+    assert_eq!(res, exp);
+}
+
+
+#[test]
+fn test_str_scalar_to_primitives() {
+    let res: String = Scalar::String("a".to_string()).into();
+    assert_eq!(res, "a".to_string());
+
+    let res: String = String::from(Scalar::String("a".to_string()));
+    assert_eq!(res, "a".to_string());
+}
+
+// impl<'a> From<&'a str> for Scalar {
+//     fn from(value: &'a str) -> Self {
+//         if value == "Null" {
+//             Scalar::Null
+//         } else {
+//             value.parse().map(Scalar::i64)
+//                 .or_else(|_| value.parse().map(Scalar::f64)
+//                          .or_else(|_| value.parse().map(Scalar::bool)))
+//                 .unwrap_or_else(|_| Scalar::String(value.to_string()))
+//         }
+//     }
+// }
+
+// impl From<Scalar> for String {
+//     fn from(value: Scalar) -> Self {
+//         match value {
+//             Scalar::i64(val) => val.to_string(),
+//             Scalar::f64(val) => val.to_string(),
+//             Scalar::bool(val) => val.to_string(),
+//             Scalar::String(val) => val,
+//             _ => panic!("Unable to convert to primitive")
+//         }
+//     }
+// }
+
+#[test]
+fn test_scalar_to_primitives_as_string() {
+    // Null
+    let exp = "Null";
+    let res: String = Scalar::Null.into();
+    assert_eq!(res, exp);
+
+    let res: String = String::from(Scalar::Null);
+    assert_eq!(res, exp);
+
+    // f64
+    let exp = "0.1";
+    let res: String = Scalar::f64(0.1).into();
+    assert_eq!(res, exp);
+
+    let res: String = String::from(Scalar::f64(0.1));
+    assert_eq!(res, exp);
+
+    // i64
+    let exp = "10";
+    let res: String = Scalar::i64(10).into();
+    assert_eq!(res, exp);
+
+    let res: String = String::from(Scalar::i64(10));
+    assert_eq!(res, exp);
+
+    // bool
+    let exp = "true";
+    let res: String = Scalar::bool(true).into();
+    assert_eq!(res, exp);
+
+    let res: String = String::from(Scalar::bool(true));
+    assert_eq!(res, exp);
+
+    // String
+    let exp = "Hello world";
+    let res: String = Scalar::String("Hello world".to_string()).into();
+    assert_eq!(res, exp);
+
+    let res: String = String::from(Scalar::String("Hello world".to_string()));
+    assert_eq!(res, exp);
+}
+
+#[test]
+fn test_primitives_as_str_to_scalar() {
+    // Null
+    let exp = Scalar::Null;
+    let res: Scalar = "Null".into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from("Null");
+    assert_eq!(res, exp);
+
+    // f64
+    let exp = Scalar::f64(0.1);
+    let res: Scalar = "0.1".into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from("0.1");
+    assert_eq!(res, exp);
+
+    // i64
+    let exp = Scalar::i64(10);
+    let res: Scalar = "10".into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from("10");
+    assert_eq!(res, exp);
+
+    // bool
+    let exp = Scalar::bool(true);
+    let res: Scalar = "true".into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from("true");
+    assert_eq!(res, exp);
+
+    // String
+    let exp = Scalar::String("Hello world".to_string());
+    let res: Scalar = "Hello world".into();
+    assert_eq!(res, exp);
+
+    let res: Scalar = Scalar::from("Hello world");
+    assert_eq!(res, exp);
+}


### PR DESCRIPTION
- Removes rustc_serialize dependency
- Adds implementations to convert to/from strings
- Adds category to Cargo.tom
- Moves convert test to its own file

Changes needed to make this work:
https://github.com/sinhrks/brassfibre/pull/38

@sinhrks 